### PR TITLE
Patch 1 - Corrections for the "time_5" and "test" variables

### DIFF
--- a/GeneToKmer.py
+++ b/GeneToKmer.py
@@ -110,6 +110,7 @@ def filter_kmers(gene, loc_strings, glistquery_command, max_count, out_file):
 
     # When glistquery has finished, keep those that are in the output (Filtering step: uniqueness, 1 mismatch)
     #removed = []
+    time_5 = time.time()
     with open(query_file, "r") as r:
         query_kmers = set()
         for line in r:

--- a/KmerToCN.py
+++ b/KmerToCN.py
@@ -396,13 +396,13 @@ option1 = seq_files_arg is not None and gene_files_arg is not None and flanking_
 option2 = seq_files_arg is not None and kmer_db is not None and kmer_paths is not None
 option3 = list_file is not None and kmer_list is not None and kmer_paths is not None
 
-if sum([option1, option2, option3]) != 1 and test is None:
+if sum([option1, option2, option3]) != 1 and (test == False):
     print("Possible combinations of options:\n1) -g -f -s\n2) -db -kp -s\n3) -kl -kp -l")
     parser.print_usage()
     print("Use -h for more information")
     quit()
 
-if (option1 or option2) and test is None:
+if (option1 or option2) and (test == False):
     seq_files = parse_filenames(seq_files_arg)
     if option1:
         gene_files = parse_filenames(gene_files_arg)


### PR DESCRIPTION
Commit 1: In _filter_kmers()_ from _GeneToKmer.py_, _time_5_ was used but not defined. 

Commit 2: In _KmerToCN.py_ the _test_ variable is compared to _None_ to check the combination of inputs given as arguments.  But _test_ is either _True_ or _False_. Changed the if statements after the arguments parsing to account for that.